### PR TITLE
Update to bypass pyppeteer if needed and fix acronym crash

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ from flask import (
 )
 from flask_misaka import Misaka
 from waitress import serve
-from summarize import get_summarized_reviews
+from summarize import get_summarized_reviews, get_summary_purely_from_ai
 
 app = Flask(__name__)
 Misaka(app)
@@ -27,9 +27,16 @@ def index():
 async def get_summary():
     name = request.args.get("name")
     location = request.args.get("location")
+    checkbox = request.args.get("checkbox")
     try:
-        app.logger.warning(f"Getting summarized reviews for {name} in {location}")
-        result = await get_summarized_reviews(name, location)
+        if checkbox:
+            app.logger.warning(
+                f"Getting summarized reviews for {name} in {location} purely from AI"
+            )
+            result = await get_summary_purely_from_ai(name, location)
+        else:
+            app.logger.warning(f"Getting summarized reviews for {name} in {location}")
+            result = await get_summarized_reviews(name, location)
     except:
         error = sys.exc_info()[1]
         app.logger.error(
@@ -42,7 +49,7 @@ async def get_summary():
             "summary",
             name=name,
             location=location,
-            result=result.get("summary"),
+            result=result if checkbox else result.get("summary"),
         )
     )
 

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -36,6 +36,13 @@ object {
   z-index: 100;
 }
 
+.checkbox {
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 10pt;
+}
+
 #error-message {
   min-width: 100%;
   width: 0;

--- a/templates/error.html
+++ b/templates/error.html
@@ -71,6 +71,21 @@
                 be used.
               </div>
             </div>
+            <div class="checkbox form-check">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="flexSwitchCheckDefault"
+                name="checkbox"
+                value="true"
+              />
+              <label class="form-check-label" for="flexSwitchCheckDefault"
+                >Skip getting Google Reviews - rely solely on AI
+              </label>
+              <div id="checkboxHelp" class="form-text text-light">
+                This is faster but results are not always reliable
+              </div>
+            </div>
             <button type="submit" id="submit" class="btn btn-info">
               Summarize
             </button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,6 +73,25 @@
                 be used.
               </div>
             </div>
+            <div class="checkbox form-check">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="flexSwitchCheckDefault"
+                name="checkbox"
+                value="true"
+              />
+
+              <label class="form-check-label" for="flexSwitchCheckDefault"
+                >Skip getting Google Reviews - rely solely on AI
+              </label>
+              <!-- <small id="checkboxHelp" class="form-text text-light">
+                This is faster but results are not always reliable
+              </small> -->
+              <div id="checkboxHelp" class="form-text text-light">
+                This is faster but results are not always reliable
+              </div>
+            </div>
             <button type="submit" id="submit" class="btn btn-info">
               Summarize
             </button>


### PR DESCRIPTION
Someone keeps playing with this and entering "ubc" and "uvic" and the app crashes. This is because the Google Review search will correctly bring up the right university, but my algorithm for matching strings will throw an error because the strings are too far apart.

I've updated the error message to indicate to users why they are unable to find reviews for acronym-based searches sometimes. (YMCA should still work!).

I also added a way for people to bypass the pyppeteer scraping and just trust the AI on the summaries. It works well for cities and well-known places, but its really really really really really bad at everything else without the google reviews. However, it is MUCH faster than waiting for Chromium to download. 